### PR TITLE
Chage the moment date to utc

### DIFF
--- a/app/components/histogram/HistogramDirective.js
+++ b/app/components/histogram/HistogramDirective.js
@@ -142,16 +142,16 @@
                     }
                     data.forEach(function (datetime, index) {
                         if (index < data.length - 1) {
-                            var startDate = moment(datetime.value);
-                            var nextHour = startDate.add(1, unitOfTime);
-                            var nextDate = moment(data[index + 1].value);
+                            var startDate = moment(datetime.value).utc();
+                            var nextTimeStep = startDate.add(1, unitOfTime);
+                            var nextDateInHistogramData = moment(data[index + 1].value).utc();
                             newData.push(datetime);
-                            while (new Date(nextHour.toJSON()) < new Date(nextDate.toJSON())) {
+                            while (nextDateInHistogramData.diff(nextTimeStep) > 0) {
                                 newData.push({
                                     count: 0,
-                                    value: nextHour.toJSON()
+                                    value: nextTimeStep.toJSON()
                                 });
-                                nextHour = nextHour.add(1, unitOfTime);
+                                nextTimeStep = nextTimeStep.add(1, unitOfTime);
                             }
                         }
                     });


### PR DESCRIPTION
## What does this PR do?
The histogram gap issue is due to an error on the date library `moment.js` and the specific timezome GTM-4, that's why in the massachusetts region the gap was seen.
The bug was fixed just passing the dates to UTC

### Screenshot
![image](https://user-images.githubusercontent.com/7197750/27038860-36a1dba0-4f5a-11e7-8f9e-ebac50d04f9d.png)

### Related Issue
https://github.com/cga-harvard/bop-ui/issues/6